### PR TITLE
Implement Into<String> for PushToken

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,12 @@ impl FromStr for PushToken {
     }
 }
 
+impl Into<String> for PushToken {
+    fn into(self) -> String {
+        self.0
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct PushResponse<T>
 where


### PR DESCRIPTION
This implements extraction of the underlying String value - otherwise there's no way to get it without hacking around using `Debug` impl (useful when handling the zipped created push messages with receipts after pushing to unregister the token).