### PR TITLE
Upgrade reqwest to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-reqwest = "0.9.18"
+reqwest = {version = "0.10.4", features = ["blocking", "json"]}
 serde_json = "1"
 serde_derive = "1"
 serde = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ pub struct PushNotifier {
     pub url: String,
     pub pushes_per_request: usize,
     pub gzip_policy: GzipPolicy,
-    client: reqwest::Client,
+    client: reqwest::blocking::Client,
 }
 
 impl PushNotifier {
@@ -293,7 +293,7 @@ impl PushNotifier {
             url: "https://exp.host/--/api/v2/push/send".to_string(),
             pushes_per_request: 100,
             gzip_policy: GzipPolicy::default(),
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
         }
     }
 
@@ -358,7 +358,7 @@ impl PushNotifier {
                 }
             }
         };
-        let mut res = self.request_async(url, &body, should_compress)?;
+        let res = self.request_async(url, &body, should_compress)?;
         let res = res.json::<PushResponse<Value>>()?;
         Ok(res.data)
     }
@@ -368,7 +368,7 @@ impl PushNotifier {
         url: &str,
         body: &str,
         should_compress: bool,
-    ) -> Result<reqwest::Response, Error> {
+    ) -> Result<reqwest::blocking::Response, Error> {
         let mut headers = HeaderMap::new();
         headers.insert(ACCEPT, "application/json".parse().unwrap());
         headers.insert(ACCEPT_ENCODING, "gzip".parse().unwrap());
@@ -384,12 +384,12 @@ impl PushNotifier {
         }
     }
 
-    fn construct_body<T: Into<reqwest::Body>>(
+    fn construct_body<T: Into<reqwest::blocking::Body>>(
         &self,
         url: &str,
         headers: HeaderMap,
         body: T,
-    ) -> Result<reqwest::Response, Error> {
+    ) -> Result<reqwest::blocking::Response, Error> {
         let response = self
             .client
             .post(url)


### PR DESCRIPTION
This PR is only upgrading reqwest client to 0.10. It is still using blocking version of a client with relevant blocking::Body and blocking::Request structures so no functional changes.

Motivation:
Reqwest 0.10 is using tokio 0.2 which is commonly used accross apps now, for us this will help to reduce compile time as we are using tokio 0.2.