### PR TITLE
Add link to maintained Rust client library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ This Rust push notifications client library is no longer actively maintained. We recommend using [expo-push-notificaton-client-rush](https://github.com/katayama8000/expo-push-notification-client-rust).
+
 # Expo Push Notification Rust Client
 
 The Expo Push Notification client provides a way for you to send push notifications to users of your mobile app using the Expo push notification services. For more details on the Expo push notification service, go [here] (https://docs.expo.io/versions/latest/guides/push-notifications)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-⚠️ This Rust push notifications client library is no longer actively maintained. We recommend using [expo-push-notificaton-client-rush](https://github.com/katayama8000/expo-push-notification-client-rust).
+⚠️ This Rust push notifications client library is no longer actively maintained. We recommend using [expo-push-notificaton-client-rust](https://github.com/katayama8000/expo-push-notification-client-rust).
 
 # Expo Push Notification Rust Client
 


### PR DESCRIPTION
I recently updated our recommendation for the Rust push notifications library in our docs in this PR https://github.com/expo/expo/pull/27116.

This PR adds a note to this repo's README, in case anyone still finds this repo.